### PR TITLE
Fix typo: "maintainance" to "maintenance

### DIFF
--- a/epitome/mode/maintain/reconcile_conditions.go
+++ b/epitome/mode/maintain/reconcile_conditions.go
@@ -11,12 +11,12 @@ import (
 )
 
 func (a *agent) updateBaronConditions() error {
-	// first, update the base condition of "maintainance robot is active"
+	// first, update the base condition of "maintenance robot is active"
 
 	conditions := []argo.ApplicationCondition{
 		{
 			Type:    "RobotActive",
-			Message: "Epitome Maintainance Robot is Active",
+			Message: "Epitome Maintenance Robot is Active",
 			LastTransitionTime: &metav1.Time{
 				Time: time.Now(),
 			},


### PR DESCRIPTION


### **Description:**

This is a minor pull request that corrects a typo of "maintainance" to "maintenance" within the `epitome/mode/maintain/reconcile_conditions.go` file.

**Changes include:**
*   Corrected the spelling in a comment.
*   Updated the `Message` field in the `ApplicationCondition` to reflect the correct spelling.

